### PR TITLE
Use Next.js Link for sidebar navigation

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import {
   Sidebar,
   SidebarContent,
@@ -36,12 +38,12 @@ export function AppSidebar() {
                       asChild
                       className="hover:bg-blue-50 dark:hover:bg-blue-900/50 transition-colors duration-200"
                     >
-                      <a href={item.url} className="flex items-center gap-3 py-2">
+                      <Link href={item.url} className="flex items-center gap-3 py-2">
                         <div className="p-1.5 bg-blue-100 dark:bg-blue-900 rounded-md">
                           <Icon className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                         </div>
                         <span className="font-medium">{item.title}</span>
-                      </a>
+                      </Link>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                 );

--- a/apps/web/src/components/job-postings-list.tsx
+++ b/apps/web/src/components/job-postings-list.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useEffect } from "react";
+
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { JobPostingDTO } from "@/types/job-postings";
@@ -62,14 +64,14 @@ export function JobPostingsList() {
                 asChild
                 className="hover:bg-green-50 dark:hover:bg-green-900/50 transition-all duration-200 hover:translate-x-1"
               >
-                <a href={"/postings/" + item.id} className="flex items-center gap-3 py-2 group">
+                <Link href={"/postings/" + item.id} className="flex items-center gap-3 py-2 group">
                   <div className="p-1.5 bg-green-100 dark:bg-green-900 rounded-md group-hover:bg-green-200 dark:group-hover:bg-green-800 transition-colors">
                     <FileText className="h-4 w-4 text-green-600 dark:text-green-400" />
                   </div>
                   <span className="font-medium text-sm truncate" title={item.title}>
                     {item.title}
                   </span>
-                </a>
+                </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
           ))}


### PR DESCRIPTION
## Summary
- replace sidebar anchor tags with Next.js Link components to enable client-side routing
- ensure job posting links also leverage Link for consistent navigation behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d47639ccd483278a4e0a3202b46f2a